### PR TITLE
add esm bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # To reproduce the bug
 `npm run dev` then navigate to localhost:3000
 
+## Solution
 
+* add `  serverDependenciesToBundle: ["react-charts", "d3-time-format"],` to remix.coonfig.js
+
+This is a ESM module issue, see docs for details:
+
+https://remix.run/docs/en/v1/pages/gotchas#importing-esm-packages

--- a/remix.config.js
+++ b/remix.config.js
@@ -5,4 +5,5 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
+  serverDependenciesToBundle: ["react-charts", "d3-time-format"],
 };


### PR DESCRIPTION
Bare in mind as you use other react-charts api, more bundles might crop up with the same error.

Not sure why remix-utils didn't pick these up.  I just add the bundles until the error messages stopped.  Maybe @kiliman might know?